### PR TITLE
Even stricter float checks

### DIFF
--- a/lib/parse-geopoint.js
+++ b/lib/parse-geopoint.js
@@ -10,7 +10,7 @@ var _ = require('lodash');
 // Stricter parsing function, from
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat
 function isFloat(value) {
-  return (/^(\-|\+)?([0-9]+(\.[0-9]+)?|Infinity)$/).test(value);
+  return (/^(\-|\+)?([0-9]+(\.[0-9]+)|Infinity)$/).test(value);
 }
 
 function withinBounds(latitude, longitude) {

--- a/test/fixtures/simple-geo-point.geojson
+++ b/test/fixtures/simple-geo-point.geojson
@@ -9,8 +9,8 @@
         "location": {
             "latitude": 0.0808311,
             "longitude": -76.8624342,
-            "altitude": 0,
-            "precision": 2725
+            "altitude": 0.0,
+            "precision": 2725.0
         },
         "meta": {
             "instanceId": "uuid:43654dc3-a22f-4d1b-9f4f-7471f62bb154",

--- a/test/fixtures/simple-geo-point.json
+++ b/test/fixtures/simple-geo-point.json
@@ -2,8 +2,8 @@
     "location": {
         "latitude": 0.0808311,
         "longitude": -76.8624342,
-        "altitude": 0,
-        "precision": 2725
+        "altitude": 0.0,
+        "precision": 2725.0
     },
     "meta": {
         "instanceId": "uuid:43654dc3-a22f-4d1b-9f4f-7471f62bb154",

--- a/test/parse-geopoint.js
+++ b/test/parse-geopoint.js
@@ -7,18 +7,13 @@ var _ = require('lodash');
 
 describe('parse-geopoint', function () {
   var geopoints = {
-    '0 0 0 0': {
-      latitude: 0,
-      longitude: 0,
-      altitude: 0, 
-      precision: 0
+    '0.0 0.0 0.0 0.0': {
+      latitude: 0.0,
+      longitude: 0.0,
+      altitude: 0.0,
+      precision: 0.0
     },
-    '-90 -180 1000 5': {
-      latitude: -90.0,
-      longitude: -180.0,
-      altitude: 1000.0,
-      precision: 5.0
-    },
+    '-90 -180 1000 5': '-90 -180 1000 5',
     '-90.0 -180.0 1000.0 5.0': {
       latitude: -90.0,
       longitude: -180.0,

--- a/xform-to-json.js
+++ b/xform-to-json.js
@@ -45,7 +45,7 @@ function coerceProperties(value) {
 
 // List of sorted keynames on a location object
 // (used for identifying valid location objects)
-var locationKeys = Object.keys(parseGeopoint('0 0 0 0')).sort();
+var locationKeys = Object.keys(parseGeopoint('0.0 0.0 0.0 0.0')).sort();
 
 // Returns true for a location field
 function isLocation(value) {


### PR DESCRIPTION
`geopoints` will always contain decimal points; this will allow for differentiation from a `select_multiple` with 4 values.

Fixes #1

Refs AmericanRedCross/OpenMapKitServer#59